### PR TITLE
Mount OpenAPI schema to Boardlight and Blueboard and fix overwriting node_modules when mounting volumes

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -11,6 +11,7 @@ services:
       ConnectionStrings__DefaultConnection: Host=db;Database=BlueboardDb;Username=postgres;Password=postgres
     volumes:
       - ./Blueboard:/app/Blueboard
+      - ./openapi_dev:/app/openapi_dev
   db:
     image: postgres:17-alpine
     environment:
@@ -31,6 +32,7 @@ services:
       - 80:80
     volumes:
       - ./Boardlight:/app/Boardlight
+      - ./openapi_dev:/app/openapi_dev
     depends_on:
       - blueboard
     environment:

--- a/docker/Dockerfile.boardlight-dev
+++ b/docker/Dockerfile.boardlight-dev
@@ -7,4 +7,4 @@ COPY ./openapi_dev /app/
 COPY ./Boardlight /app/
 WORKDIR /app/Boardlight
 EXPOSE 80
-CMD pnpm dev --host
+CMD pnpm install && pnpm dev --host

--- a/docker/Dockerfile.boardlight-dev
+++ b/docker/Dockerfile.boardlight-dev
@@ -3,6 +3,7 @@ RUN corepack enable pnpm
 WORKDIR /app
 COPY ./Boardlight/package.json /app/
 RUN pnpm install
+COPY ./openapi_dev /app/
 COPY ./Boardlight /app/
 WORKDIR /app/Boardlight
 EXPOSE 80


### PR DESCRIPTION
Mivel nem találtam jobb megoldást, ezért a Dockerfile-ban kétszer szerepel a pnpm install (a végén, a CMD parancsban is), így ha egy volume-ot csatlakoztatunk, akkor a csatlakoztatása után is lefut a `pnpm install`, így biztosan lesz node_modules mappa.